### PR TITLE
use package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "CPM.cmake": {
       "version": "0.30.0",
-      "resolved": "git+https://github.com/cpm-cmake/CPM.cmake#v0.30.0"
+      "from": "git+https://github.com/cpm-cmake/CPM.cmake#v0.30.0"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,7 +3,7 @@
   "lockfileVersion": 1,
   "dependencies": {
     "CPM.cmake": {
-      "version": "git+https://github.com/cpm-cmake/CPM.cmake.git#v0.30.1",
+      "version": "0.31.1",
       "from": "git+https://github.com/cpm-cmake/CPM.cmake.git#v0.30.1"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,8 +3,8 @@
   "lockfileVersion": 1,
   "dependencies": {
     "CPM.cmake": {
-      "version": "0.30.0",
-      "from": "git+https://github.com/cpm-cmake/CPM.cmake#v0.30.0"
+      "version": "0.31.1",
+      "from": "git+https://github.com/cpm-cmake/CPM.cmake.git#v0.30.1"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "CPM.cmake": {
       "version": "0.31.1",
-      "from": "git+https://github.com/cpm-cmake/CPM.cmake.git#v0.30.1"
+      "from": "git+https://github.com/cpm-cmake/CPM.cmake.git#v0.31.1"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,7 +3,7 @@
   "lockfileVersion": 1,
   "dependencies": {
     "CPM.cmake": {
-      "version": "0.31.1",
+      "version": "git+https://github.com/cpm-cmake/CPM.cmake.git#v0.30.1",
       "from": "git+https://github.com/cpm-cmake/CPM.cmake.git#v0.30.1"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "CPM.cmake": {
+      "version": "0.30.0",
+      "resolved": "git+https://github.com/cpm-cmake/CPM.cmake#v0.30.0"
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-CPM.cmake@git+https://github.com/cpm-cmake/CPM.cmake@v0.31.1


### PR DESCRIPTION
Here's an example using npm's `package-lock.json` format. GitHub correctly identifies the dependency, however it seems it's not able to associate the resolved git repo from it.

![image](https://user-images.githubusercontent.com/4437447/109118654-e1d0be00-7743-11eb-8758-cd01d01e4f0c.png)

